### PR TITLE
Also set scroll view background color

### DIFF
--- a/src/ios/WebViewColor.m
+++ b/src/ios/WebViewColor.m
@@ -7,6 +7,7 @@
     NSString *hexColor = [command.arguments objectAtIndex:0];
     UIColor *theColor = [self colorFromHexString:hexColor];
     self.webView.backgroundColor = theColor; 
+    self.webView.scrollView.backgroundColor = theColor;
     self.viewController.view.backgroundColor = theColor;
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
 }


### PR DESCRIPTION
When rotating the device on iOS the default background color is still visible.
This also adjusts the `scrollView.backgroundColor` to remove this issue.

If this isn't what this plugin is intended for, let me know.
I just thought I open a PR before creating a new plugin just for this.